### PR TITLE
Update auth proxy

### DIFF
--- a/cf/opensearch-dashboards-manifest.yml
+++ b/cf/opensearch-dashboards-manifest.yml
@@ -7,7 +7,7 @@
 
 version: 1
 applications:
-- name: opensearch-dashboards
+- name: test-opensearch-dashboards
   memory: 1G
   instances: 1
   disk_quota: 2G

--- a/cf/opensearch-manifest.yml
+++ b/cf/opensearch-manifest.yml
@@ -7,7 +7,7 @@
 
 version: 1
 applications:
-- name: opensearch
+- name: test-opensearch
   memory: 3G
   instances: 1
   disk_quota: 2G

--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -9,7 +9,7 @@ version: 1
 applications:
 - name: ((app_name))
   health_check_type: port
-  instances: 2
+  instances: ((num_instances))
   buildpacks:
     - python_buildpack
   routes:

--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -7,7 +7,7 @@
 
 version: 1
 applications:
-- name: auth-proxy
+- name: ((app_name))
   health_check_type: port
   instances: 2
   buildpacks:

--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -16,7 +16,7 @@ applications:
     - route: ((public_route))
   env:
     FLASK_ENV: local
-    DASHBOARD_URL: http://dashboard-test.apps.internal:5601
+    DASHBOARD_URL: ((dashboard_url))
     CF_ADMIN_GROUP_NAME: "cloud_controller.admin"
     CF_API_URL: ((cf_url))
     UAA_AUTH_URL: ((uaa_auth_url))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -76,9 +76,10 @@ jobs:
           uaa_client_secret: ((dev-uaa-client-secret))
           secret_key: ((dev-secret-key))
           session_lifetime: "3600"
-          public_route: ((dev-public-url))
+          public_route: ((dev-test-public-url))
           dashboard_url: ((dev-test-dashboard-url))
           app_name: test-auth-proxy
+          num_instances: 1
 
     - task: update-networking
       image: general-task
@@ -215,6 +216,7 @@ jobs:
           public_route: ((dev-public-url))
           dashboard_url: ((dev-dashboard-url))
           app_name: auth-proxy
+          num_instances: 1
 
 ##########################
 #  RESOURCES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -47,7 +47,7 @@ jobs:
         tag_as_latest: true
         cache: true
 
-- name: cf
+- name: deploy-test-apps
   plan:
     - in_parallel:
       - get: src
@@ -77,7 +77,8 @@ jobs:
           secret_key: ((dev-secret-key))
           session_lifetime: "3600"
           public_route: ((dev-public-url))
-          dashboard_url: ((dev-dashboard-url))
+          dashboard_url: ((dev-test-dashboard-url))
+          app_name: test-auth-proxy
 
     - task: update-networking
       image: general-task
@@ -191,6 +192,29 @@ jobs:
           TEST_USER_4_PASSWORD: ((dev-test-user-4-password))
           TEST_USER_4_TOTP_SEED: ((dev-test-user-4-totp-seed))
 
+- name: deploy-dev
+  plan:
+    - get: src
+      params: {depth: 1}
+      trigger: true
+      passed: [build-test-images]
+      # passed: [e2e] uncomment once e2e tests are fixed
+    
+    - put: cf-dev
+      params:
+        path: src
+        manifest: src/cf/proxy-manifest.yml
+        vars:
+          cf_url: ((dev-cf-api-url))
+          uaa_auth_url: ((dev-uaa-auth-url))
+          uaa_base_url: ((dev-uaa-base-url))
+          uaa_client_id: ((dev-uaa-client-id))
+          uaa_client_secret: ((dev-uaa-client-secret))
+          secret_key: ((dev-secret-key))
+          session_lifetime: "3600"
+          public_route: ((dev-public-url))
+          dashboard_url: ((dev-dashboard-url))
+          app_name: auth-proxy
 
 ##########################
 #  RESOURCES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -77,6 +77,7 @@ jobs:
           secret_key: ((dev-secret-key))
           session_lifetime: "3600"
           public_route: ((dev-public-url))
+          dashboard_url: ((dev-dashboard-url))
 
     - task: update-networking
       image: general-task


### PR DESCRIPTION
## Changes proposed in this pull request:

- Rename apps used for e2e tests to start with `test-*`
- Add separate CI step for deploying auth proxy app that will actually be used for proxying to logs customer on Opensearch in dev
- Add more variables for auth proxy app manifest

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

See https://github.com/cloud-gov/private/issues/800
