### PR TITLE
fix pipeline job name reference

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -102,7 +102,7 @@ jobs:
       - get: src
         params: {depth: 1}
         trigger: true
-        passed: [cf]
+        passed: [deploy-test-apps]
       - get: general-task
     - task: provision-cf-access
       image: general-task


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
