### PR TITLE
Fix and refactor e2e tests

### DIFF
--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -33,7 +33,6 @@ def log_in(user, page, start_at=None):
     login_button.wait_for()
     login_button.click()
 
-    # totp_field = page.get_by_role("input", name="j_tokenNumber")
     totp_field = page.locator("css=input[id='j_tokenNumber']")
     totp_field.wait_for()
     totp_field.fill(user.totp.now())


### PR DESCRIPTION
Related to https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy/issues/66

## Changes proposed in this pull request:

- Refactor e2e tests to use updated Playwright helper methods
- Update e2e tests to rely less on CSS identifiers in favor of element text that may be more durable/reliable

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Making sure the e2e tests are passing is a critical piece of ensuring that this [authentication proxy for Opensearch](https://opensearch.org/docs/latest/security/authentication-backends/proxy/) works as expected and guaranteeing tenant isolation of data
