### PR TITLE
fix networking script 

### DIFF
--- a/cf/opensearch-dashboards-manifest.yml
+++ b/cf/opensearch-dashboards-manifest.yml
@@ -7,7 +7,7 @@
 
 version: 1
 applications:
-- name: test-opensearch-dashboards
+- name: ((app_name))
   memory: 1G
   instances: 1
   disk_quota: 2G

--- a/cf/opensearch-manifest.yml
+++ b/cf/opensearch-manifest.yml
@@ -7,7 +7,7 @@
 
 version: 1
 applications:
-- name: test-opensearch
+- name: ((app_name))
   memory: 3G
   instances: 1
   disk_quota: 2G

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -59,10 +59,14 @@ jobs:
     - put: cf-dev
       params:
         manifest: src/cf/opensearch-manifest.yml
-    
+        vars:
+          app_name: ((dev-test-opensearch-app-name))
+
     - put: cf-dev
       params:
         manifest: src/cf/opensearch-dashboards-manifest.yml
+        vars:
+          app_name: ((dev-test-opensearch-dashboards-app-name))
     
     - put: cf-dev
       params:
@@ -78,7 +82,7 @@ jobs:
           session_lifetime: "3600"
           public_route: ((dev-test-public-url))
           dashboard_url: ((dev-test-dashboard-url))
-          app_name: test-auth-proxy
+          app_name: ((dev-test-auth-proxy-app-name))
           num_instances: "1"
 
     - task: update-networking
@@ -95,6 +99,9 @@ jobs:
         CF_PASSWORD: ((dev-cf-password))
         CF_ORGANIZATION: ((dev-cf-organization))
         CF_SPACE: ((dev-cf-space))
+        OPENSEARCH_APP_NAME: ((dev-test-opensearch-app-name))
+        DASHBOARDS_APP_NAME: ((dev-test-opensearch-dashboards-app-name))
+        PROXY_APP_NAME: ((dev-test-auth-proxy-app-name))
 
 - name: e2e
   plan:

--- a/ci/update-networking.sh
+++ b/ci/update-networking.sh
@@ -9,9 +9,9 @@ pushd ${dir}
 trap popd exit
 
 cf api ${CF_API_URL}
-cf auth 
+cf auth
 cf t -o ${CF_ORGANIZATION} -s ${CF_SPACE}
 
 sleep 10
 
-../dev cf-network
+../dev cf-network "$OPENSEARCH_APP_NAME" "$DASHBOARDS_APP_NAME" "$PROXY_APP_NAME"

--- a/dev
+++ b/dev
@@ -124,8 +124,15 @@ cf_push() {
 }
 
 cf_network() {
-  cf add-network-policy opensearch-dashboards opensearch --protocol tcp --port 9200
-  cf add-network-policy auth-proxy opensearch-dashboards --protocol tcp --port 5601
+  if [[ $# -lt 3 ]]; then
+    echo "Three arguments required: opensearch app name, dashboards app name, and proxy app name"
+    exit 1
+  fi
+  OPENSEARCH_APP_NAME="$1"
+  DASHBOARDS_APP_NAME="$2"
+  PROXY_APP_NAME="$3"
+  cf add-network-policy "$DASHBOARDS_APP_NAME" "$OPENSEARCH_APP_NAME" --protocol tcp --port 9200
+  cf add-network-policy "$PROXY_APP_NAME" "$DASHBOARDS_APP_NAME" --protocol tcp --port 5601
 }
 
 main() {
@@ -178,10 +185,10 @@ main() {
       ;;
     cf-push)
       cf_push
-      cf_network
+      cf_network "$@"
       ;;
     cf-network)
-      cf_network
+      cf_network "$@"
       ;;
     watch-test|watch-tests)
       watch_tests "$@"


### PR DESCRIPTION
Related to #66 

## Changes proposed in this pull request:

- Remove harcoding of app names and use Credhub vars for app names
- Remove app name hardcoding in CF networking script and interpolate app names received from environment variables

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Making sure the e2e tests are passing is a critical piece of ensuring that this [authentication proxy for Opensearch](https://opensearch.org/docs/latest/security/authentication-backends/proxy/) works as expected and guaranteeing tenant isolation of data
