### PR TITLE
fix hardcoding of app name in init-config script

### DIFF
--- a/ci/init-config.sh
+++ b/ci/init-config.sh
@@ -14,7 +14,7 @@ cf auth
 cf t -o "${CF_ORGANIZATION}" -s "${CF_SPACE}"
 
 echo "Creating SSH tunnel"
-cf ssh -L 9200:opensearch-test.apps.internal:9200 -L 5601:dashboard-test.apps.internal:5601 opensearch-dashboards -N &
+cf ssh -L 9200:opensearch-test.apps.internal:9200 -L 5601:dashboard-test.apps.internal:5601 "${DASHBOARDS_APP_NAME}" -N &
 ssh_pid=$!
 
 echo "Waiting for tunnel to come up ..."

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -169,6 +169,8 @@ jobs:
         
         CF_ORG_ID_1_BOTH_ORGS_SPACE: ((dev-test-org-1-both-orgs-space-id))
         CF_ORG_ID_2_BOTH_ORGS_SPACE: ((dev-test-org-2-both-orgs-space-id))
+
+        DASHBOARDS_APP_NAME: ((dev-test-opensearch-dashboards-app-name))
         
     - task: e2e-tests
       config:


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix hardcoding of app name when creating tunnel in init-config script

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Making sure the e2e tests are passing is a critical piece of ensuring that this [authentication proxy for Opensearch](https://opensearch.org/docs/latest/security/authentication-backends/proxy/) works as expected and guaranteeing tenant isolation of data
