### PR TITLE
Update tests

### DIFF
--- a/cf/opensearch-dashboards-manifest.yml
+++ b/cf/opensearch-dashboards-manifest.yml
@@ -7,7 +7,7 @@
 
 version: 1
 applications:
-- name: ((app_name))
+- name: ((dashboards_app_name))
   memory: 2G
   instances: 1
   disk_quota: 2G

--- a/cf/opensearch-dashboards-manifest.yml
+++ b/cf/opensearch-dashboards-manifest.yml
@@ -8,7 +8,7 @@
 version: 1
 applications:
 - name: ((app_name))
-  memory: 1G
+  memory: 2G
   instances: 1
   disk_quota: 2G
   docker:

--- a/cf/opensearch-manifest.yml
+++ b/cf/opensearch-manifest.yml
@@ -8,7 +8,7 @@
 version: 1
 applications:
 - name: ((app_name))
-  memory: 3G
+  memory: 4G
   instances: 1
   disk_quota: 2G
   routes:

--- a/cf/opensearch-manifest.yml
+++ b/cf/opensearch-manifest.yml
@@ -7,7 +7,7 @@
 
 version: 1
 applications:
-- name: ((app_name))
+- name: ((opensearch_app_name))
   memory: 4G
   instances: 1
   disk_quota: 2G

--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -7,9 +7,9 @@
 
 version: 1
 applications:
-- name: ((app_name))
+- name: ((auth_proxy_app_name))
   health_check_type: port
-  instances: ((num_instances))
+  instances: ((auth_proxy_num_instances))
   buildpacks:
     - python_buildpack
   routes:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -83,7 +83,7 @@ jobs:
           public_route: ((dev-test-public-url))
           dashboard_url: ((dev-test-dashboard-url))
           app_name: ((dev-test-auth-proxy-app-name))
-          num_instances: "1"
+          num_instances: "2"
 
     - task: update-networking
       image: general-task
@@ -224,7 +224,7 @@ jobs:
           public_route: ((dev-public-url))
           dashboard_url: ((dev-dashboard-url))
           app_name: auth-proxy
-          num_instances: "1"
+          num_instances: "2"
 
 ##########################
 #  RESOURCES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -82,8 +82,8 @@ jobs:
           session_lifetime: "3600"
           public_route: ((dev-test-public-url))
           dashboard_url: ((dev-test-dashboard-url))
-          app_name: ((dev-test-auth-proxy-app-name))
-          num_instances: ((dev-test-auth-proxy-num-instances))
+          auth_proxy_app_name: ((dev-test-auth-proxy-app-name))
+          auth_proxy_num_instances: ((dev-test-auth-proxy-num-instances))
 
     - task: update-networking
       image: general-task
@@ -223,8 +223,8 @@ jobs:
           session_lifetime: "3600"
           public_route: ((dev-public-url))
           dashboard_url: ((dev-dashboard-url))
-          app_name: auth-proxy
-          num_instances: ((dev-auth-proxy-num-instances))
+          auth_proxy_app_name: auth-proxy
+          auth_proxy_num_instances: ((dev-auth-proxy-num-instances))
 
 ##########################
 #  RESOURCES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -83,7 +83,7 @@ jobs:
           public_route: ((dev-test-public-url))
           dashboard_url: ((dev-test-dashboard-url))
           app_name: ((dev-test-auth-proxy-app-name))
-          num_instances: "2"
+          num_instances: ((dev-test-auth-proxy-num-instances))
 
     - task: update-networking
       image: general-task
@@ -224,7 +224,7 @@ jobs:
           public_route: ((dev-public-url))
           dashboard_url: ((dev-dashboard-url))
           app_name: auth-proxy
-          num_instances: "2"
+          num_instances: ((dev-auth-proxy-num-instances))
 
 ##########################
 #  RESOURCES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -76,8 +76,8 @@ jobs:
           cf_url: ((dev-cf-api-url))
           uaa_auth_url: ((dev-uaa-auth-url))
           uaa_base_url: ((dev-uaa-base-url))
-          uaa_client_id: ((dev-uaa-client-id))
-          uaa_client_secret: ((dev-uaa-client-secret))
+          uaa_client_id: ((dev-uaa-test-client-id))
+          uaa_client_secret: ((dev-uaa-test-client-secret))
           secret_key: ((dev-secret-key))
           session_lifetime: "3600"
           public_route: ((dev-test-public-url))

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ x-opensearch-node-common-vars: &x-opensearch-node-common-vars
   discovery.seed_hosts: opensearch-node1,opensearch-node2
   cluster.initial_master_nodes: opensearch-node1,opensearch-node2
   bootstrap.memory_lock: true # along with the memlock settings below, disables swapping
-  OPENSEARCH_JAVA_OPTS: "-Xms2048m -Xmx2048m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+  OPENSEARCH_JAVA_OPTS: "-Xms4096m -Xmx4096m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
   plugins.security.audit.type: debug
 
 x-opensearch-node: &x-opensearch-node

--- a/docker/opensearch/dockerfile
+++ b/docker/opensearch/dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2 as opensearch
+FROM opensearchproject/opensearch:2.9.0 as opensearch
 
 # ok, this is a little weird.
 # we're building this image to run on Cloud Foundry, where we can

--- a/docker/opensearch_dashboards/dockerfile
+++ b/docker/opensearch_dashboards/dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch-dashboards:2 AS opensearch-dashboards
+FROM opensearchproject/opensearch-dashboards:2.9.0 AS opensearch-dashboards
 
 
 FROM scratch

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -30,6 +30,7 @@ def user_2():
     )
     return user_2
 
+
 @pytest.fixture
 def user_3():
     user_3_username = getenv(f"TEST_USER_3_USERNAME")
@@ -41,6 +42,7 @@ def user_3():
         user_3_totp_seed,
     )
     return user_3
+
 
 @pytest.fixture
 def user_4():

--- a/e2e/test_discover_filters_logs.py
+++ b/e2e/test_discover_filters_logs.py
@@ -1,5 +1,6 @@
 from .utils import log_in, switch_tenants, go_to_discover_page
 
+
 def test_see_correct_logs_in_discover_user_1(user_1, page):
     log_in(user=user_1, page=page)
 
@@ -14,15 +15,20 @@ def test_see_correct_logs_in_discover_user_1(user_1, page):
 
     space_should_exist_results = page.query_selector_all("text=space_id_1")
     assert len(space_should_exist_results) >= 1
-    
+
     should_not_exist_results = page.query_selector_all("text=/(org|space)_id_2/")
     assert len(should_not_exist_results) == 0
 
-    space_should_not_exist_results = page.query_selector_all("text=org_1_both_orgs_space")
+    space_should_not_exist_results = page.query_selector_all(
+        "text=org_1_both_orgs_space"
+    )
     assert len(space_should_not_exist_results) == 0
 
-    space_should_not_exist_results = page.query_selector_all("text=org_2_both_orgs_space")
+    space_should_not_exist_results = page.query_selector_all(
+        "text=org_2_both_orgs_space"
+    )
     assert len(space_should_not_exist_results) == 0
+
 
 def test_see_correct_logs_in_discover_user_2(user_2, page):
     log_in(user=user_2, page=page)
@@ -42,11 +48,14 @@ def test_see_correct_logs_in_discover_user_2(user_2, page):
     should_not_exist_results = page.query_selector_all("text=/(org|space)_id_1/")
     assert len(should_not_exist_results) == 0
 
-    space_should_not_exist_results = page.query_selector_all("text=org_1_both_orgs_space")
+    space_should_not_exist_results = page.query_selector_all(
+        "text=org_1_both_orgs_space"
+    )
     assert len(space_should_not_exist_results) == 0
 
     space_should_exist_results = page.query_selector_all("text=org_2_both_orgs_space")
     assert len(space_should_exist_results) >= 1
+
 
 def test_see_correct_logs_in_discover_user_3(user_3, page):
     log_in(user=user_3, page=page)
@@ -62,18 +71,23 @@ def test_see_correct_logs_in_discover_user_3(user_3, page):
 
     org_should_exist_results = page.query_selector_all("text=org_id_2")
     assert len(org_should_exist_results) == 0
-    
+
     space_should_exist_results = page.query_selector_all("text=space_id_1")
     assert len(space_should_exist_results) >= 1
 
     space_should_exist_results = page.query_selector_all("text=space_id_2")
     assert len(space_should_exist_results) >= 1
 
-    space_should_not_exist_results = page.query_selector_all("text=org_1_both_orgs_space")
+    space_should_not_exist_results = page.query_selector_all(
+        "text=org_1_both_orgs_space"
+    )
     assert len(space_should_not_exist_results) == 0
 
-    space_should_not_exist_results = page.query_selector_all("text=org_2_both_orgs_space")
+    space_should_not_exist_results = page.query_selector_all(
+        "text=org_2_both_orgs_space"
+    )
     assert len(space_should_not_exist_results) == 0
+
 
 def test_see_correct_logs_in_discover_user_4(user_4, page):
     log_in(user=user_4, page=page)
@@ -89,7 +103,7 @@ def test_see_correct_logs_in_discover_user_4(user_4, page):
 
     org_should_exist_results = page.query_selector_all("text=org_id_2")
     assert len(org_should_exist_results) == 0
-    
+
     space_should_exist_results = page.query_selector_all("text=space_id_1")
     assert len(space_should_exist_results) == 0
 
@@ -99,5 +113,7 @@ def test_see_correct_logs_in_discover_user_4(user_4, page):
     space_should_exist_results = page.query_selector_all("text=org_1_both_orgs_space")
     assert len(space_should_exist_results) >= 1
 
-    space_should_not_exist_results = page.query_selector_all("text=org_2_both_orgs_space")
+    space_should_not_exist_results = page.query_selector_all(
+        "text=org_2_both_orgs_space"
+    )
     assert len(space_should_not_exist_results) == 0

--- a/e2e/test_setup.py
+++ b/e2e/test_setup.py
@@ -1,27 +1,23 @@
+from urllib.parse import urljoin
 from . import AUTH_PROXY_URL
 from .utils import log_in
-
-import pytest
-
 
 def test_redirects_to_login(page):
     page.goto(AUTH_PROXY_URL)
     assert "login" in page.url
 
-
 def test_login_redirects_home_without_slash(page, user_1):
-    # this tests an actual bug where going to the home page without (e.g. logs.example.com)
-    # a trailing slash causes a redirect to an invalid endpoint.
-    log_in(user_1, page, AUTH_PROXY_URL[:-1])
+    # this tests an actual bug where going to the home page without
+    # a trailing slash (e.g. logs.example.com) causes a redirect
+    # to an invalid endpoint.
+    log_in(user_1, page, str.rstrip(AUTH_PROXY_URL, "/"))
     assert page.url.startswith(f"{AUTH_PROXY_URL}app/home")
-
 
 def test_login_redirects_home(page, user_1):
     # this tests the basic case - going to logs.example.com/
     log_in(user_1, page)
-    assert page.url.startswith(f"{AUTH_PROXY_URL}app/home")
-
+    assert page.url.startswith(urljoin(AUTH_PROXY_URL, "app/home"))
 
 def test_login_remembers_target(page, user_1):
     log_in(user_1, page, f"{AUTH_PROXY_URL}app/dev_tools")
-    assert page.url.startswith(f"{AUTH_PROXY_URL}app/dev_tools")
+    assert page.url.startswith(urljoin(AUTH_PROXY_URL, "app/dev_tools"))

--- a/e2e/test_setup.py
+++ b/e2e/test_setup.py
@@ -2,9 +2,11 @@ from urllib.parse import urljoin
 from . import AUTH_PROXY_URL
 from .utils import log_in
 
+
 def test_redirects_to_login(page):
     page.goto(AUTH_PROXY_URL)
     assert "login" in page.url
+
 
 def test_login_redirects_home_without_slash(page, user_1):
     # this tests an actual bug where going to the home page without
@@ -13,10 +15,12 @@ def test_login_redirects_home_without_slash(page, user_1):
     log_in(user_1, page, str.rstrip(AUTH_PROXY_URL, "/"))
     assert page.url.startswith(f"{AUTH_PROXY_URL}app/home")
 
+
 def test_login_redirects_home(page, user_1):
     # this tests the basic case - going to logs.example.com/
     log_in(user_1, page)
     assert page.url.startswith(urljoin(AUTH_PROXY_URL, "app/home"))
+
 
 def test_login_remembers_target(page, user_1):
     log_in(user_1, page, f"{AUTH_PROXY_URL}app/dev_tools")

--- a/e2e/user.py
+++ b/e2e/user.py
@@ -1,5 +1,6 @@
 import pyotp
 
+
 class User:
     def __init__(self, username, password, totp_seed):
         self.username = username

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -2,9 +2,8 @@ import re
 
 from . import AUTH_PROXY_URL
 
-
 def log_in(user, page, start_at=None):
-    page.set_default_timeout(15000)
+    page.set_default_timeout(60000)
 
     if start_at is None:
         start_at = AUTH_PROXY_URL
@@ -43,6 +42,7 @@ def log_in(user, page, start_at=None):
     
     # lots of redirects and stuff happen here, so just, like, chill, ok?
     page.wait_for_load_state("networkidle")
+
     if "/authorize?" in page.url:
         # first time using this app with this user
         authorize_button = page.get_by_text("Authorize")
@@ -50,9 +50,12 @@ def log_in(user, page, start_at=None):
         authorize_button.click()
         page.wait_for_load_state("networkidle")
 
+    page.wait_for_url(f"{AUTH_PROXY_URL}*")
+
     # handle first-login stuff when it's here
     page.wait_for_timeout(5000)
-    if "Start by adding your data" in page.content():
+
+    if page.get_by_text("Start by adding your data").is_visible():
         explore_button = page.get_by_text("Explore on my own")
         explore_button.wait_for()
         explore_button.click()

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -2,25 +2,26 @@ import re
 
 from . import AUTH_PROXY_URL
 
+
 def log_in(user, page, start_at=None):
     page.set_default_timeout(60000)
 
     if start_at is None:
         start_at = AUTH_PROXY_URL
-    
+
     # go to opensearch dashboard
     page.goto(start_at)
-    
+
     # accept the monitoring notice
     agree_continue_button = page.get_by_text("AGREE AND CONTINUE")
     agree_continue_button.wait_for()
     agree_continue_button.click()
-    
+
     # select the cloud.gov IdP
     cloud_gov_idp_button = page.get_by_role("link", name="cloud.gov")
     cloud_gov_idp_button.wait_for()
     cloud_gov_idp_button.click()
-    
+
     username_field = page.get_by_label("Email address")
     password_field = page.get_by_label("Password")
     username_field.wait_for()
@@ -39,7 +40,7 @@ def log_in(user, page, start_at=None):
     login_button = page.get_by_text("Login")
     login_button.wait_for()
     login_button.click()
-    
+
     # lots of redirects and stuff happen here, so just, like, chill, ok?
     page.wait_for_load_state("networkidle")
 
@@ -60,6 +61,7 @@ def log_in(user, page, start_at=None):
         explore_button.wait_for()
         explore_button.click()
 
+
 def switch_tenants(page, tenant="Global"):
     """
     switch to the specified tenant.
@@ -76,11 +78,13 @@ def switch_tenants(page, tenant="Global"):
     # todo: there is a page refresh that happens after submitting the tenant option.
     # we should wait on an element instead of arbitrary timeout
     page.wait_for_timeout(2000)
-    
+
 
 def go_to_discover_page(page):
     # open the hamburger menu
-    hamburger_button = page.locator(f"css=div.euiHeaderSectionItem.euiHeaderSectionItem--borderRight.header__toggleNavButtonSection")
+    hamburger_button = page.locator(
+        f"css=div.euiHeaderSectionItem.euiHeaderSectionItem--borderRight.header__toggleNavButtonSection"
+    )
     hamburger_button.wait_for()
     hamburger_button.click()
 
@@ -92,7 +96,7 @@ def go_to_discover_page(page):
     # wait for the refresh button, signifying the discover page has loaded
     refresh_button = page.get_by_text("Refresh")
     refresh_button.wait_for()
-    
+
     # the box the results are in
     content_box = page.locator("css=div.dscWrapper__content")
     content_box.wait_for()


### PR DESCRIPTION
## Changes proposed in this pull request:

- Increase memory for test apps
- Pin Opensearch Docker images to 2.9.0
- Refactor tests to reduce flakiness

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Making sure the e2e tests are passing is a critical piece of ensuring that this [authentication proxy for Opensearch](https://opensearch.org/docs/latest/security/authentication-backends/proxy/) works as expected and guaranteeing tenant isolation of data
