### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test-results
 .DS_STORE
 *.vars
 *.log
+ci-test-results

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ To retain video records of failed tests:
 ./dev e2e-local --video retain-on-failure
 ```
 
+To retain a trace of failed tests:
+
+```shell
+./dev e2e-local --tracing retain-on-failure
+```
+
 ### Adding client
 
 In order to run the app locally, you will need to create a UAA client application.

--- a/README.md
+++ b/README.md
@@ -91,3 +91,23 @@ Lastly, update your `.env` value to set these values:
 
 - `UAA_CLIENT_ID=<my_client_name>`
 - `UAA_CLIENT_SECRET=<my_client_secret>`
+
+## Downloading test results from CI
+
+When the e2e tests run in CI, artifacts such as video recordings or traces from failed test runs may be created. To download these artifacts, use the provided script:
+
+```shell
+./scripts/download-e2e-ci-results.sh <BUILD_NUMBER>
+```
+
+`BUILD_NUMBER` should be the number of the failed `e2e` job from the pipeline.
+
+To view downloaded trace files:
+
+```shell
+playwright show-trace ci-test-results/<dir>/trace.zip
+```
+
+where `<dir>` is an abitrary directory name generated for the test run by Playwright.
+
+See <https://playwright.dev/python/docs/trace-viewer> for more information about working with Playwright traces.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To retain video records of failed tests:
 ./dev e2e-local --video retain-on-failure
 ```
 
-To retain a trace of failed tests:
+To retain a [trace](https://playwright.dev/python/docs/trace-viewer-intro) of failed tests:
 
 ```shell
 ./dev e2e-local --tracing retain-on-failure

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -7,4 +7,4 @@ apt-get update
 apt-get install -y python3-venv
 
 src/dev set-up-ci-environment
-src/dev e2e --video retain-on-failure
+src/dev e2e --video retain-on-failure --tracing retain-on-failure

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -7,4 +7,4 @@ apt-get update
 apt-get install -y python3-venv
 
 src/dev set-up-ci-environment
-src/dev e2e --video retain-on-failure --tracing retain-on-failure
+src/dev e2e --tracing retain-on-failure

--- a/ci/init-config.sh
+++ b/ci/init-config.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 shopt -s inherit_errexit || true
-dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 function cleanup() {
   [[ -n "${ssh_pid:-}" ]] && kill "${ssh_pid}"
@@ -20,7 +19,4 @@ ssh_pid=$!
 echo "Waiting for tunnel to come up ..."
 sleep 10
 
-pushd "${dir}/.."
-  bash "dev seed-es-data"
-popd
-
+./dev seed-es-data

--- a/ci/init-config.sh
+++ b/ci/init-config.sh
@@ -20,4 +20,7 @@ ssh_pid=$!
 echo "Waiting for tunnel to come up ..."
 sleep 10
 
-bash "${dir}/../dev seed-es-data"
+pushd "${dir}/.."
+  bash "dev seed-es-data"
+popd
+

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -153,7 +153,8 @@ jobs:
         inputs:
         - name: src
         run:
-          path: src/ci/init-config.sh
+          dir: src
+          path: ci/init-config.sh
       params:
         <<: *dev-cf-auth-params
 
@@ -164,7 +165,7 @@ jobs:
         CF_ORG_2_NAME: ((dev-test-org-2-name))
 
         CF_ORG_1_SPACE_1_NAME: ((dev-test-org-1-space-1-name))
-        CF_ORG_2_SPACE_2_NAME: ((dev-test-org-1-space-2-name))
+        CF_ORG_2_SPACE_2_NAME: ((dev-test-org-2-space-2-name))
 
         BOTH_ORGS_SPACE_NAME: ((dev-test-both-orgs-space-name))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -235,7 +235,7 @@ resources:
   check_every: 10s
   source:
     uri: https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy
-    branch: main
+    branch: fix-tests
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: dev-opensearch-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -180,7 +180,7 @@ jobs:
           type: docker-image
           source:
             repository: mcr.microsoft.com/playwright
-            tag: focal
+            tag: jammy
         run:
           path: src/ci/e2e.sh
         params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -164,7 +164,7 @@ jobs:
         CF_ORG_2_NAME: ((dev-test-org-2-name))
 
         CF_ORG_1_SPACE_1_NAME: ((dev-test-org-1-space-1-name))
-        CF_ORG_2_SPACE_2_NAME: ((dev-test-org-1-space-1-name))
+        CF_ORG_2_SPACE_2_NAME: ((dev-test-org-1-space-2-name))
 
         BOTH_ORGS_SPACE_NAME: ((dev-test-both-orgs-space-name))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -236,7 +236,7 @@ resources:
   check_every: 10s
   source:
     uri: https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy
-    branch: fix-tests
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: dev-opensearch-image

--- a/e2e/test_setup.py
+++ b/e2e/test_setup.py
@@ -7,7 +7,6 @@ def test_redirects_to_login(page):
     page.goto(AUTH_PROXY_URL)
     assert "login" in page.url
 
-
 def test_login_redirects_home_without_slash(page, user_1):
     # this tests an actual bug where going to the home page without
     # a trailing slash (e.g. logs.example.com) causes a redirect
@@ -15,12 +14,10 @@ def test_login_redirects_home_without_slash(page, user_1):
     log_in(user_1, page, str.rstrip(AUTH_PROXY_URL, "/"))
     assert page.url.startswith(urljoin(AUTH_PROXY_URL, "app/home"))
 
-
 def test_login_redirects_home(page, user_1):
     # this tests the basic case - going to logs.example.com/
     log_in(user_1, page)
     assert page.url.startswith(urljoin(AUTH_PROXY_URL, "app/home"))
-
 
 def test_login_remembers_target(page, user_1):
     log_in(user_1, page, urljoin(AUTH_PROXY_URL, "app/dev_tools"))

--- a/e2e/test_setup.py
+++ b/e2e/test_setup.py
@@ -13,7 +13,7 @@ def test_login_redirects_home_without_slash(page, user_1):
     # a trailing slash (e.g. logs.example.com) causes a redirect
     # to an invalid endpoint.
     log_in(user_1, page, str.rstrip(AUTH_PROXY_URL, "/"))
-    assert page.url.startswith(f"{AUTH_PROXY_URL}app/home")
+    assert page.url.startswith(urljoin(AUTH_PROXY_URL, "app/home"))
 
 
 def test_login_redirects_home(page, user_1):
@@ -23,5 +23,5 @@ def test_login_redirects_home(page, user_1):
 
 
 def test_login_remembers_target(page, user_1):
-    log_in(user_1, page, f"{AUTH_PROXY_URL}app/dev_tools")
+    log_in(user_1, page, urljoin(AUTH_PROXY_URL, "app/dev_tools"))
     assert page.url.startswith(urljoin(AUTH_PROXY_URL, "app/dev_tools"))

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -59,13 +59,6 @@ def switch_tenants(page, tenant="Global"):
     """
     tenant_option = page.get_by_text(re.compile(f"^{tenant}.*$"))
     tenant_option.wait_for()
-        
-    welcome_heading = page.get_by_role("heading", name="Welcome to OpenSearch Dashboards")
-    if welcome_heading.is_visible():
-        explore_button = page.get_by_text("Explore on my own")
-        explore_button.wait_for()
-        explore_button.click()
-
     tenant_option.click()
 
     # submit
@@ -76,6 +69,12 @@ def switch_tenants(page, tenant="Global"):
     # wait for loading screen
     loading_text = page.get_by_text("Loading OpenSearch Dashboards")
     loading_text.wait_for()
+
+    welcome_heading = page.get_by_role("heading", name="Welcome to OpenSearch Dashboards")
+    if welcome_heading.is_visible():
+        explore_button = page.get_by_text("Explore on my own")
+        explore_button.wait_for()
+        explore_button.click()
 
     # wait for dashboard to finish loading
     home_title = page.get_by_role("heading", name="Home")

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -59,8 +59,9 @@ def switch_tenants(page, tenant="Global"):
     """
     tenant_option = page.get_by_text(re.compile(f"^{tenant}.*$"))
     tenant_option.wait_for()
-    
-    if page.get_by_text("Start by adding your data").is_visible():
+        
+    welcome_heading = page.get_by_role("heading", name="Welcome to OpenSearch Dashboards")
+    if welcome_heading.is_visible():
         explore_button = page.get_by_text("Explore on my own")
         explore_button.wait_for()
         explore_button.click()

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -53,10 +53,6 @@ def log_in(user, page, start_at=None):
     # wait for redirect to auth proxy from OAuth URL
     page.wait_for_url(f"{AUTH_PROXY_URL}*")
 
-    # wait for dashboard to finish loading
-    home_title = page.get_by_text("Home")
-    home_title.wait_for()
-
 def switch_tenants(page, tenant="Global"):
     """
     switch to the specified tenant.

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -1,3 +1,4 @@
+import math
 import re
 import time
 
@@ -57,7 +58,7 @@ def log_in(user, page, start_at=None):
 def handle_welcome_message(page):
     total_wait_period_secs = 10
     wait_between_retry_secs = 0.25
-    num_retries = total_wait_period_secs / wait_between_retry_secs
+    num_retries = math.floor(total_wait_period_secs / wait_between_retry_secs)
 
     # this welcome page can appear anywhere in the dashboard loading process,
     # so we're waiting to see if it appears and handling it

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 from . import AUTH_PROXY_URL, UAA_AUTH_URL
 
@@ -54,64 +55,45 @@ def log_in(user, page, start_at=None):
     page.wait_for_url(f"{AUTH_PROXY_URL}*")
 
 def handle_welcome_message(page):
-    welcome_heading = page.get_by_role("heading", name="Welcome to OpenSearch Dashboards")
-    if welcome_heading.is_visible():
-        explore_button = page.get_by_text("Explore on my own")
-        explore_button.wait_for()
-        explore_button.click()
+    total_wait_period_secs = 10
+    wait_between_retry_secs = 0.25
+    num_retries = total_wait_period_secs / wait_between_retry_secs
+
+    # this welcome page can appear anywhere in the dashboard loading process,
+    # so we're waiting to see if it appears and handling it
+    for i in range(1, num_retries):
+        welcome_heading = page.get_by_role("heading", name="Welcome to OpenSearch Dashboards")
+        if welcome_heading.is_visible():
+            explore_button = page.get_by_text("Explore on my own")
+            explore_button.wait_for()
+            explore_button.click()
+        
+        time.sleep(wait_between_retry_secs)
 
 def switch_tenants(page, tenant="Global"):
     """
     switch to the specified tenant.
     """
 
-    # this welcome page can appear anywhere in the dashboard loading process,
-    # so we're checking for it before/after every assertion so we can close it
-    # if it appears, otherwise the tests will fail
     handle_welcome_message(page)
 
     tenant_option = page.get_by_text(re.compile(f"^{tenant}.*$"))
-    
-    handle_welcome_message(page)
-    
     tenant_option.wait_for()
-    
-    handle_welcome_message(page)
-    
     tenant_option.click()
-    
-    handle_welcome_message(page)
 
     # submit
     submit_button = page.get_by_text("Confirm")
 
-    handle_welcome_message(page)
-
     submit_button.wait_for()
-    
-    handle_welcome_message(page)
-
     submit_button.click()
-
-    handle_welcome_message(page)
 
     # wait for loading screen
     loading_text = page.get_by_text("Loading OpenSearch Dashboards")
-
-    handle_welcome_message(page)
-    
     loading_text.wait_for()
-    
-    handle_welcome_message(page)
 
     # wait for dashboard to finish loading
     home_title = page.get_by_role("heading", name="Home")
-    
-    handle_welcome_message(page)
-
     home_title.wait_for()
-
-    handle_welcome_message(page)
 
 def go_to_discover_page(page):
     # open the hamburger menu

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -53,32 +53,65 @@ def log_in(user, page, start_at=None):
     # wait for redirect to auth proxy from OAuth URL
     page.wait_for_url(f"{AUTH_PROXY_URL}*")
 
-def switch_tenants(page, tenant="Global"):
-    """
-    switch to the specified tenant.
-    """
-    tenant_option = page.get_by_text(re.compile(f"^{tenant}.*$"))
-    tenant_option.wait_for()
-    tenant_option.click()
-
-    # submit
-    submit_button = page.get_by_text("Confirm")
-    submit_button.wait_for()
-    submit_button.click()
-
-    # wait for loading screen
-    loading_text = page.get_by_text("Loading OpenSearch Dashboards")
-    loading_text.wait_for()
-
+def handle_welcome_message(page):
     welcome_heading = page.get_by_role("heading", name="Welcome to OpenSearch Dashboards")
     if welcome_heading.is_visible():
         explore_button = page.get_by_text("Explore on my own")
         explore_button.wait_for()
         explore_button.click()
 
+def switch_tenants(page, tenant="Global"):
+    """
+    switch to the specified tenant.
+    """
+
+    # this welcome page can appear anywhere in the dashboard loading process,
+    # so we're checking for it before/after every assertion so we can close it
+    # if it appears, otherwise the tests will fail
+    handle_welcome_message(page)
+
+    tenant_option = page.get_by_text(re.compile(f"^{tenant}.*$"))
+    
+    handle_welcome_message(page)
+    
+    tenant_option.wait_for()
+    
+    handle_welcome_message(page)
+    
+    tenant_option.click()
+    
+    handle_welcome_message(page)
+
+    # submit
+    submit_button = page.get_by_text("Confirm")
+
+    handle_welcome_message(page)
+
+    submit_button.wait_for()
+    
+    handle_welcome_message(page)
+
+    submit_button.click()
+
+    handle_welcome_message(page)
+
+    # wait for loading screen
+    loading_text = page.get_by_text("Loading OpenSearch Dashboards")
+
+    handle_welcome_message(page)
+    
+    loading_text.wait_for()
+    
+    handle_welcome_message(page)
+
     # wait for dashboard to finish loading
     home_title = page.get_by_role("heading", name="Home")
+    
+    handle_welcome_message(page)
+
     home_title.wait_for()
+
+    handle_welcome_message(page)
 
 def go_to_discover_page(page):
     # open the hamburger menu

--- a/e2e/utils.py
+++ b/e2e/utils.py
@@ -59,7 +59,7 @@ def switch_tenants(page, tenant="Global"):
     """
     tenant_option = page.get_by_text(re.compile(f"^{tenant}.*$"))
     tenant_option.wait_for()
-
+    
     if page.get_by_text("Start by adding your data").is_visible():
         explore_button = page.get_by_text("Explore on my own")
         explore_button.wait_for()
@@ -73,7 +73,7 @@ def switch_tenants(page, tenant="Global"):
     submit_button.click()
 
     # wait for loading screen
-    loading_text = page.get_by_text("Loading Opensearch Dashboards")
+    loading_text = page.get_by_text("Loading OpenSearch Dashboards")
     loading_text.wait_for()
 
     # wait for dashboard to finish loading

--- a/scripts/download-e2e-ci-results.sh
+++ b/scripts/download-e2e-ci-results.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+BUILD_NUMBER=$1
+
+if [[ -z "$BUILD_NUMBER" ]]; then
+  echo "build number is required as first argument"
+  exit 1
+fi
+
+CI_TASK_TARGET="fly -t ci intercept -j opensearch-dashboards-cf-auth-proxy/e2e -s e2e-tests -b $BUILD_NUMBER"
+TEST_RESULTS_DIR="src/test-results"
+LOCAL_TARGET_DIR="ci-test-results"
+
+for test_dir in $($CI_TASK_TARGET -- ls $TEST_RESULTS_DIR); do
+  echo "found test dir: $test_dir"
+
+  for file in $($CI_TASK_TARGET -- ls "$TEST_RESULTS_DIR/$test_dir"); do
+    mkdir -p "$LOCAL_TARGET_DIR/$test_dir"
+    $CI_TASK_TARGET -- cat "$TEST_RESULTS_DIR/$test_dir/$file" > "$LOCAL_TARGET_DIR/$test_dir/$file"
+    echo "downloaded $file"
+  done
+done


### PR DESCRIPTION
Related to https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy/issues/66

## Changes proposed in this pull request:

- Changed Playwright image in CI to use `jammy` tag
- Fixed variable references in pipeline definition
- Updated CI runs of e2e tests to use `--tracing retain-on-failures` to preserve [Playwright traces](https://playwright.dev/python/docs/trace-viewer) on failed test runs
- Added documentation for running/debugging e2e tests
- Added helper script for downloading artifacts from failed e2e test CI runs
- Added e2e test code to wait for "welcome message" to appear for 10 seconds and dismiss it if it appears 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Making sure the e2e tests are passing is a critical piece of ensuring that this [authentication proxy for Opensearch](https://opensearch.org/docs/latest/security/authentication-backends/proxy/) works as expected and guaranteeing tenant isolation of data
