### PR TITLE
Update proxy use dashboard certs

### DIFF
--- a/dev
+++ b/dev
@@ -234,8 +234,7 @@ main() {
       ;;
     serve)
       source_env_vars
-      export FLASK_APP="opensearch_dashboards_cf_auth_proxy.app:create_app()"
-      
+      export FLASK_APP="cf_auth_proxy.app:create_app()"
       ${python} -m flask run -p "${PORT}"
       ;;
     cluster)

--- a/src/cf_auth_proxy/config.py
+++ b/src/cf_auth_proxy/config.py
@@ -92,3 +92,7 @@ class AppConfig(Config):
         self.SECRET_KEY = self.env_parser.str("SECRET_KEY")
         self.PERMANENT_SESSION_LIFETIME = self.env_parser.int("SESSION_LIFETIME")
         self.CF_ADMIN_GROUP_NAME = self.env_parser.str("CF_ADMIN_GROUP_NAME")
+
+        self.DASHBOARD_CERTIFICATE = self.env_parser.str("DASHBOARD_CERTIFICATE")
+        self.DASHBOARD_CERTIFICATE_KEY = self.env_parser.str("DASHBOARD_CERTIFICATE_KEY")
+        self.DASHBOARD_CERTIFICATE_CA = self.env_parser.str("DASHBOARD_CERTIFICATE_CA")

--- a/src/cf_auth_proxy/proxy.py
+++ b/src/cf_auth_proxy/proxy.py
@@ -2,6 +2,8 @@ from flask import Response
 
 import requests
 
+from cf_auth_proxy.extensions import config
+
 
 def proxy_request(url, headers, data, cookies, method):
     resp = requests.request(
@@ -11,6 +13,8 @@ def proxy_request(url, headers, data, cookies, method):
         data=data,
         cookies=cookies,
         allow_redirects=False,
+        cert=(config.DASHBOARD_CERTIFICATE, config.DASHBOARD_CERTIFICATE_KEY),
+        verify=config.DASHBOARD_CERTIFICATE_CA
     )
 
     excluded_headers = [


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update proxy use dashboard certs when making requests to dashboards

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

These changes make the proxy more secure by forcing it to communicate over TLS using the configured certificates for the dashboards
