### PR TITLE
Fix findings from Bandit

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -4,5 +4,4 @@ set -euo pipefail
 shopt -s inherit_errexit
 
 src/dev set-up-environment
-src/venv/bin/bandit -r src/src/cf_auth_proxy
 src/dev test

--- a/dev
+++ b/dev
@@ -227,6 +227,7 @@ main() {
       export FLASK_ENV=unit
       ${python} -m piptools sync requirements.txt dev-requirements.txt
       ${python} -m pip install -e .
+      ${python} -m bandit -r src/cf_auth_proxy
       ${python} -m pytest tests
       ;;
     provision-cf-access)

--- a/src/cf_auth_proxy/app.py
+++ b/src/cf_auth_proxy/app.py
@@ -33,6 +33,7 @@ def create_app():
                         "token_format": "opaque",
                         "refresh_token": session["refresh_token"],
                     },
+                    timeout=config.REQUEST_TIMEOUT
                 )
                 try:
                     r.raise_for_status()
@@ -80,6 +81,7 @@ def create_app():
             auth=requests.auth.HTTPBasicAuth(
                 config.UAA_CLIENT_ID, config.UAA_CLIENT_SECRET
             ),
+            timeout=config.REQUEST_TIMEOUT
         )
         try:
             r.raise_for_status()

--- a/src/cf_auth_proxy/config.py
+++ b/src/cf_auth_proxy/config.py
@@ -23,6 +23,8 @@ class Config:
             "PERMITTED_ORG_ROLES", ["organization_manager", "organization_auditor"]
         )
         self.SESSION_COOKIE_NAME = "cfsession"
+        # see https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+        self.REQUEST_TIMEOUT = 30
 
 
 class UnitConfig(Config):

--- a/src/cf_auth_proxy/config.py
+++ b/src/cf_auth_proxy/config.py
@@ -37,10 +37,10 @@ class UnitConfig(Config):
         self.CF_API_URL = "http://mock.cf/"
         self.UAA_AUTH_URL = "http://mock.uaa/authorize"
         self.UAA_BASE_URL = "http://mock.uaa/"
-        self.UAA_TOKEN_URL = "http://mock.uaa/token"
+        self.UAA_TOKEN_URL = "http://mock.uaa/token" # nosec
         self.UAA_CLIENT_ID = "EXAMPLE"
-        self.UAA_CLIENT_SECRET = "example"
-        self.SECRET_KEY = "CHANGEME"
+        self.UAA_CLIENT_SECRET = "example" # nosec
+        self.SECRET_KEY = "CHANGEME" # nosec
         self.PERMANENT_SESSION_LIFETIME = 120
         self.SESSION_REFRESH_EACH_REQUEST = False
         self.CF_ADMIN_GROUP_NAME = "cloud_controller.admin"

--- a/src/cf_auth_proxy/uaa.py
+++ b/src/cf_auth_proxy/uaa.py
@@ -16,6 +16,7 @@ def get_client_credentials_token():
         auth=requests.auth.HTTPBasicAuth(
             config.UAA_CLIENT_ID, config.UAA_CLIENT_SECRET
         ),
+        timeout=config.REQUEST_TIMEOUT
     )
 
     try:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -25,6 +25,7 @@ def test_config_loads(monkeypatch):
         "organization_auditor",
     ]
     assert config.CF_ADMIN_GROUP_NAME == "cloud_controller.admin"
+    assert config.REQUEST_TIMEOUT == 30
 
 
 @pytest.mark.parametrize(
@@ -59,6 +60,7 @@ def test_local_config(monkeypatch, dashboard_url):
     assert config.DASHBOARD_CERTIFICATE == None
     assert config.DASHBOARD_CERTIFICATE_KEY == None
     assert config.DASHBOARD_CERTIFICATE_CA == None
+    assert config.REQUEST_TIMEOUT == 30
 
 
 @pytest.mark.parametrize(
@@ -105,3 +107,4 @@ def test_prod_config(monkeypatch, dashboard_url):
     assert config.DASHBOARD_CERTIFICATE == "fake-cert"
     assert config.DASHBOARD_CERTIFICATE_KEY == "fake-key"
     assert config.DASHBOARD_CERTIFICATE_CA == "fake-ca"
+    assert config.REQUEST_TIMEOUT == 30


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR fixes or ignores results found by Bandit: https://github.com/PyCQA/bandit

The only results which were ignored are false positives for https://bandit.readthedocs.io/en/1.7.5/plugins/b105_hardcoded_password_string.html coming from the unit test config in `config.py`.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Addressing these findings is an improvement for security and operational reliability
