### PR TITLE
remove deployment of proxy app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 "opensearch_dashboards_cf_auth_proxy.app:create_app()"
+web: gunicorn --access-logfile - --error-logfile - --log-level info --timeout 300 "cf_auth_proxy.app:create_app()"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -201,30 +201,6 @@ jobs:
           TEST_USER_4_PASSWORD: ((dev-test-user-4-password))
           TEST_USER_4_TOTP_SEED: ((dev-test-user-4-totp-seed))
 
-- name: deploy-dev
-  plan:
-    - get: src
-      params: {depth: 1}
-      trigger: true
-      # change to e2e once tests are fixed
-      passed: [test]
-    - put: cf-dev
-      params:
-        path: src
-        manifest: src/cf/proxy-manifest.yml
-        vars:
-          cf_url: ((dev-cf-api-url))
-          uaa_auth_url: ((dev-uaa-auth-url))
-          uaa_base_url: ((dev-uaa-base-url))
-          uaa_client_id: ((dev-uaa-client-id))
-          uaa_client_secret: ((dev-uaa-client-secret))
-          secret_key: ((dev-secret-key))
-          session_lifetime: "3600"
-          public_route: ((dev-public-url))
-          dashboard_url: ((dev-dashboard-url))
-          auth_proxy_app_name: auth-proxy
-          auth_proxy_num_instances: ((dev-auth-proxy-num-instances))
-
 ##########################
 #  RESOURCES
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/919

- remove deployment of proxy app now that it is integrated with the BOSH deployment directly

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No security impact directly, just removing unneeded resources
