### PR TITLE
putting in fix so that the values will come in correct

### DIFF
--- a/cf_auth_proxy/app.py
+++ b/cf_auth_proxy/app.py
@@ -176,11 +176,12 @@ def create_app():
         # allowed path
         if session.get("user_id"):
             headers["x-proxy-user"] = session["email"]
-            roles = sorted(
-                [("admin" if session.get("is_cf_admin") else "user")]
-                + session.get("user_orgs", [])
+            roles = (
+                ("admin" if session.get("is_cf_admin") else "user")
+                + ","
+                + list_to_ext_header(session.get("user_orgs", [])).replace('"', "")
             )
-            headers["x-proxy-roles"] = list_to_ext_header(roles)
+            headers["x-proxy-roles"] = roles
 
         # TODO: add x-forwarded-for functionality
         headers["x-forwarded-for"] = "127.0.0.1"


### PR DESCRIPTION
## Changes proposed in this pull request:

- roles come in as  "backend_roles": [
            "\"cf_guid"",
            "\"user\""
  ] currently which changes the backend role, this fixes it so it comes in without the quotes
-
-

## Security considerations

None
