### PR TITLE
quote json in yaml so it stays as a string

### DIFF
--- a/cf/proxy-manifest.yml
+++ b/cf/proxy-manifest.yml
@@ -23,7 +23,7 @@ applications:
     UAA_BASE_URL: ((uaa_base_url))
     UAA_CLIENT_ID: ((uaa_client_id))
     UAA_CLIENT_SECRET: ((uaa_client_secret))
-    UAA_JWKS: ((uaa_jwks))
+    UAA_JWKS: "((uaa_jwks))"
     SECRET_KEY: ((secret_key))
     SESSION_LIFETIME: ((session_lifetime))
   memory: 2G


### PR DESCRIPTION
## Changes proposed in this pull request:

- quote json in yaml so it stays as a string

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None 