### PR TITLE
Fix roles header behavior + test

### DIFF
--- a/cf_auth_proxy/app.py
+++ b/cf_auth_proxy/app.py
@@ -174,12 +174,9 @@ def create_app():
         # allowed path
         if session.get("user_id"):
             headers["x-proxy-user"] = session["email"]
-            roles = (
-                ("admin" if session.get("is_cf_admin") else "user")
-                + ","
-                + list_to_ext_header(session.get("user_orgs", [])).replace('"', "")
-            )
-            headers["x-proxy-roles"] = roles
+            roles = [("admin" if session.get("is_cf_admin") else "user")]
+            roles += session.get("user_orgs", [])
+            headers["x-proxy-roles"] = list_to_ext_header(roles)
 
         # TODO: add x-forwarded-for functionality
         headers["x-forwarded-for"] = "127.0.0.1"

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -114,7 +114,6 @@ def test_user_org_roles_set_correctly(client):
             s["user_orgs"] = ["org-1", "org-2"]
         client.get("/home")
         assert (
-            m.last_request._request.headers["x-proxy-roles"] == "user",
-            "org-1",
-            "org-2",
+            m.last_request._request.headers["x-proxy-roles"]
+            == '"user", "org-1", "org-2"'
         )


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix roles header behavior + test
  `pytest` helpfully flagged the current test as a no-op, because we're essentially asserting that a non-empty tuple is truthy. I put the test back to its behavior before it became a no-op and fixed the code to match. I am not 100% sure whether there should be quotes in the header (`"user", "org-1", "org-2"`) or not (`user, org-1, org-2`), but all the other headers have quotes so I'm guessing that's correct, but Jason added logic clearly meant to strip the quotes so I'm not sure. 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Testing our auth logic better is... better.