### PR TITLE
Use hardened images

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -52,39 +52,11 @@ jobs:
         :white_check_mark: Tests PASSED onopensearch-dashboards-cf-auth-proxy
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: build-test-images
-  plan:
-    - get: src-docker
-      params: {depth: 1}
-      trigger: true
-
-    - put: dev-opensearch-image
-      params:
-        build: src-docker/docker/opensearch
-        dockerfile: src-docker/docker/opensearch/dockerfile
-        tag_as_latest: true
-        cache: true
-
-    - put: dev-opensearch-dashboards-image
-      params:
-        build: src-docker/docker/opensearch_dashboards
-        dockerfile: src-docker/docker/opensearch_dashboards/dockerfile
-        tag_as_latest: true
-        cache: true
-  on_failure:
-    put: slack
-    params:
-      <<: *slack-failure-params
-      text: |
-        :x: FAILED to build test images
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-
 - name: deploy-test-apps
   plan:
     - in_parallel:
       - get: src
         params: {depth: 1}
-        trigger: true
         passed: [test]
       - get: general-task
       - get: dev-opensearch-image
@@ -296,22 +268,22 @@ resources:
       - docker
 
 - name: dev-opensearch-image
-  type: docker-image
-  icon: docker
+  type: registry-image
   source:
-    email: ((docker-email))
-    username: ((docker-username))
-    password: ((docker-password))
-    repository: cloudgovoperations/test-opensearch
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: opensearch-testing
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: dev-opensearch-dashboards-image
-  type: docker-image
-  icon: docker
+  type: registry-image
   source:
-    email: ((docker-email))
-    username: ((docker-username))
-    password: ((docker-password))
-    repository: cloudgovoperations/test-opensearch-dashboards
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: opensearch-dashboards-testing
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: cf-dev
   type: cf

--- a/docker/opensearch/dockerfile
+++ b/docker/opensearch/dockerfile
@@ -10,21 +10,20 @@ FROM opensearchproject/opensearch:2.12.0 as opensearch
 # everything into the base hardened image ¯\_(ツ)_/¯
 FROM ${base_image}
 
-WORKDIR /usr
-
-COPY --from=opensearch /usr/share/opensearch /usr/share/opensearch/
+COPY --from=opensearch /usr/share/opensearch /usr/share/opensearch
 
 ARG UID=1000
 ARG GID=1000
 ARG OPENSEARCH_HOME=/usr/share/opensearch
-WORKDIR $OPENSEARCH_HOME
 
 ENV PATH $PATH:$OPENSEARCH_HOME/bin
 
 # add the new stuff
-COPY config.yml ${OPENSEARCH_HOME}/config/opensearch-security/config.yml
-COPY roles.yml ${OPENSEARCH_HOME}/config/opensearch-security/roles.yml
-COPY roles_mapping.yml ${OPENSEARCH_HOME}/config/opensearch-security/roles_mapping.yml
+COPY docker/opensearch/config.yml ${OPENSEARCH_HOME}/config/opensearch-security/config.yml
+COPY docker/opensearch/roles.yml ${OPENSEARCH_HOME}/config/opensearch-security/roles.yml
+COPY docker/opensearch/roles_mapping.yml ${OPENSEARCH_HOME}/config/opensearch-security/roles_mapping.yml
+
+WORKDIR $OPENSEARCH_HOME
 
 # Change user
 USER $UID

--- a/docker/opensearch/dockerfile
+++ b/docker/opensearch/dockerfile
@@ -1,3 +1,5 @@
+ARG base_image
+
 FROM opensearchproject/opensearch:2.12.0 as opensearch
 
 # ok, this is a little weird.
@@ -5,8 +7,8 @@ FROM opensearchproject/opensearch:2.12.0 as opensearch
 # only have one port exposed. The upstream exposes more than one,
 # and docker doesn't provide a direct method to override it.
 # so, we're using the opensearch image as a "builder" and then copying
-# everything into scratch, which is a blank image ¯\_(ツ)_/¯
-FROM scratch
+# everything into the base hardened image ¯\_(ツ)_/¯
+FROM ${base_image}
 
 COPY --from=opensearch / /
 

--- a/docker/opensearch/dockerfile
+++ b/docker/opensearch/dockerfile
@@ -10,7 +10,7 @@ FROM opensearchproject/opensearch:2.12.0 as opensearch
 # everything into the base hardened image ¯\_(ツ)_/¯
 FROM ${base_image}
 
-COPY --from=opensearch / /
+COPY --from=opensearch /usr/share/opensearch /usr/share/opensearch
 
 ARG UID=1000
 ARG GID=1000

--- a/docker/opensearch/dockerfile
+++ b/docker/opensearch/dockerfile
@@ -10,7 +10,7 @@ FROM opensearchproject/opensearch:2.12.0 as opensearch
 # everything into the base hardened image ¯\_(ツ)_/¯
 FROM ${base_image}
 
-COPY --from=opensearch /usr/share/opensearch /usr/share/opensearch
+COPY --from=opensearch /usr/share/opensearch /usr/share/opensearch/
 
 ARG UID=1000
 ARG GID=1000

--- a/docker/opensearch/dockerfile
+++ b/docker/opensearch/dockerfile
@@ -10,6 +10,8 @@ FROM opensearchproject/opensearch:2.12.0 as opensearch
 # everything into the base hardened image ¯\_(ツ)_/¯
 FROM ${base_image}
 
+WORKDIR /usr
+
 COPY --from=opensearch /usr/share/opensearch /usr/share/opensearch/
 
 ARG UID=1000

--- a/docker/opensearch_dashboards/dockerfile
+++ b/docker/opensearch_dashboards/dockerfile
@@ -1,7 +1,9 @@
+ARG base_image
+
 FROM opensearchproject/opensearch-dashboards:2.12.0 AS opensearch-dashboards
 
 
-FROM scratch
+FROM ${base_image}
 
 COPY --from=opensearch-dashboards / /
 

--- a/docker/opensearch_dashboards/dockerfile
+++ b/docker/opensearch_dashboards/dockerfile
@@ -5,18 +5,19 @@ FROM opensearchproject/opensearch-dashboards:2.12.0 AS opensearch-dashboards
 
 FROM ${base_image}
 
-COPY --from=opensearch-dashboards / /
+COPY --from=opensearch-dashboards /usr/share/opensearch-dashboards /usr/share/opensearch-dashboards/
 
 ARG OPENSEARCH_INITIAL_ADMIN_PASSWORD
 ARG OPENSEARCH_DASHBOARDS_HOME=/usr/share/opensearch-dashboards
-WORKDIR $OPENSEARCH_DASHBOARDS_HOME
 
 ENV PATH=$OPENSEARCH_DASHBOARDS_HOME/bin:$PATH
+
+COPY docker/opensearch_dashboards/opensearch_dashboards.yml $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+WORKDIR $OPENSEARCH_DASHBOARDS_HOME
+
 USER 1000
 
 EXPOSE 5601
-
-COPY opensearch_dashboards.yml $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
 
 ENTRYPOINT ["./opensearch-dashboards-docker-entrypoint.sh"]
 CMD ["opensearch-dashboards"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the dockerfiles to use hardened image and to work with the registry-image resource
- Updates pipeline to use the new hardened image, and updates the triggers for the deploy-test-apps job so that it runs when there's new images

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating images hardened and pipeline to use the hardened image. The images have been created and added to the ECR, so this PR shouldn't cause any issues.