### PR TITLE
remove resource that is no longer used

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -256,17 +256,6 @@ resources:
     branch: ((proxy-src-code-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: src-docker
-  type: git
-  icon: github-circle
-  check_every: 10s
-  source:
-    uri: ((proxy-src-code-uri))
-    branch: ((proxy-src-code-branch))
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-    paths:
-      - docker
-
 - name: dev-opensearch-image
   type: registry-image
   source:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the src-docker resource which is no longer used

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Missed removing this resource
