### PR TITLE
use hardened images to deploy testing apps

### DIFF
--- a/cf/opensearch-dashboards-manifest.yml
+++ b/cf/opensearch-dashboards-manifest.yml
@@ -12,7 +12,7 @@ applications:
   instances: 1
   disk_quota: 2G
   docker:
-    image: cloudgovoperations/test-opensearch-dashboards:latest
+    image: ((repo))/opensearch-dashboards-testing:latest
   env:
       "OPENSEARCH_HOSTS": https://0.test-opensearch-node.apps.internal:9200
       "opensearch.requestHeadersAllowlist": "securitytenant,Authorization,x-forwarded-for,x-proxy-user,x-proxy-roles"

--- a/cf/opensearch-node-manifest.yml
+++ b/cf/opensearch-node-manifest.yml
@@ -14,7 +14,7 @@ applications:
   routes:
     - route: test-opensearch-node.apps.internal
   docker:
-    image: cloudgovoperations/test-opensearch:latest
+    image: ((repo))/opensearch-testing:latest
   env:
     # discovery.seed_hosts: '["https://0.test-opensearch-manager.apps.internal:9200","https://0.test-opensearch-node.apps.internal:9200"]'
     # cluster.initial_cluster_manager_nodes: "opensearch-manager"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -67,16 +67,22 @@ jobs:
     - put: cf-dev
       params:
         manifest: src/cf/opensearch-node-manifest.yml
+        docker_username: ((ecr_aws_key))
+        docker_password: ((ecr_aws_secret))
         vars:
           opensearch_node_app_name: ((dev-test-opensearch-node-app-name))
           opensearch_password: ((opensearch-admin-password))
+          repo: ((ecr_aws_repo))
 
     - put: cf-dev
       params:
         manifest: src/cf/opensearch-dashboards-manifest.yml
+        docker_username: ((ecr_aws_key))
+        docker_password: ((ecr_aws_secret))
         vars:
           dashboards_app_name: ((dev-test-opensearch-dashboards-app-name))
           opensearch_password: ((opensearch-admin-password))
+          repo: ((ecr_aws_repo))
 
     - put: cf-dev
       params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- This updates the cf testing apps to use the hardened images

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Using hardened images