### PR TITLE
using var for username

### DIFF
--- a/cf/opensearch-dashboards-manifest.yml
+++ b/cf/opensearch-dashboards-manifest.yml
@@ -13,6 +13,7 @@ applications:
   disk_quota: 2G
   docker:
     image: ((repo))/opensearch-dashboards-testing:latest
+    username: ((docker_username))
   env:
       "OPENSEARCH_HOSTS": https://0.test-opensearch-node.apps.internal:9200
       "opensearch.requestHeadersAllowlist": "securitytenant,Authorization,x-forwarded-for,x-proxy-user,x-proxy-roles"

--- a/cf/opensearch-node-manifest.yml
+++ b/cf/opensearch-node-manifest.yml
@@ -15,6 +15,7 @@ applications:
     - route: test-opensearch-node.apps.internal
   docker:
     image: ((repo))/opensearch-testing:latest
+    username: ((docker_username))
   env:
     # discovery.seed_hosts: '["https://0.test-opensearch-manager.apps.internal:9200","https://0.test-opensearch-node.apps.internal:9200"]'
     # cluster.initial_cluster_manager_nodes: "opensearch-manager"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -73,6 +73,7 @@ jobs:
           opensearch_node_app_name: ((dev-test-opensearch-node-app-name))
           opensearch_password: ((opensearch-admin-password))
           repo: ((ecr_aws_repo))
+          docker_username: ((ecr_aws_key))
 
     - put: cf-dev
       params:
@@ -83,6 +84,7 @@ jobs:
           dashboards_app_name: ((dev-test-opensearch-dashboards-app-name))
           opensearch_password: ((opensearch-admin-password))
           repo: ((ecr_aws_repo))
+          docker_username: ((ecr_aws_key))
 
     - put: cf-dev
       params:


### PR DESCRIPTION
## Changes proposed in this pull request:

- The docker_username param doesn't seem to be working like it should, so setting the username as a var

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just adding a variable