### PR TITLE
remove docker_username param

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -67,7 +67,6 @@ jobs:
     - put: cf-dev
       params:
         manifest: src/cf/opensearch-node-manifest.yml
-        docker_username: ((ecr_aws_key))
         docker_password: ((ecr_aws_secret))
         vars:
           opensearch_node_app_name: ((dev-test-opensearch-node-app-name))
@@ -78,7 +77,6 @@ jobs:
     - put: cf-dev
       params:
         manifest: src/cf/opensearch-dashboards-manifest.yml
-        docker_username: ((ecr_aws_key))
         docker_password: ((ecr_aws_secret))
         vars:
           dashboards_app_name: ((dev-test-opensearch-dashboards-app-name))


### PR DESCRIPTION
## Changes proposed in this pull request:

- There is a bug with the cf resource where it doesn't accept`docker_username` as a param: https://github.com/cloudfoundry-community/cf-resource/issues/48
- This PR removes that param

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing param for docker_username