### PR TITLE
Fix Opensearch test proxy config

### DIFF
--- a/dev
+++ b/dev
@@ -264,12 +264,12 @@ main() {
     start-cluster)
       source_env_vars
       pushd docker
-        docker-compose up --force-recreate --build "$@"
+        docker compose up --force-recreate --build "$@"
       popd
       ;;
     destroy-cluster)
       pushd docker
-        docker-compose down
+        docker compose down
       popd
       ;;
     cf-push)

--- a/docker/opensearch/config.yml
+++ b/docker/opensearch/config.yml
@@ -8,8 +8,8 @@ config:
     http:
       xff:
         enabled: true
-        # trust IP addresses from Docker network
-        internalProxies: '172\.19\.0.*'
+        # trust IP addresses from Docker and CF Diego network
+        internalProxies: '172\.19\.0.*|10\.255.*'
         remoteIpHeader: "x-forwarded-for"
     authc:
       basic_internal_auth_domain:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update `internalProxies` setting for test OpenSearch config (only used in CI testing) to allow incoming requests from IPs in the CF Diego network

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This configuration is only used in CI testing. We are still only allowing incoming requests from known IP ranges, now including the range for the CloudFoundry diego network.
