### PR TITLE
Update test users

### DIFF
--- a/ci/config.yml
+++ b/ci/config.yml
@@ -1,2 +1,0 @@
-proxy-src-code-uri: https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy
-proxy-src-code-branch: main

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,8 +6,8 @@ jobs:
   - get: src
     params: {depth: 1}
   - get: master-bosh-root-cert
-  - get: weekly
-    trigger: true
+  # - get: weekly
+  #   trigger: true
   - task: update-test-user-credentials
     image: general-task
     config:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -332,6 +332,15 @@ resources:
     region_name: ((aws-region))
     versioned_file: ((master-bosh-cert-file))
 
+- name: general-task
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
 # - name: weekly
 #   type: time
 #   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -5,6 +5,7 @@ jobs:
   plan:
   - get: src
     params: {depth: 1}
+  - get: master-bosh-root-cert
   - get: weekly
     trigger: true
   - task: update-test-user-credentials
@@ -12,7 +13,7 @@ jobs:
     config:
       inputs:
         - name: src
-        - name: cg-scripts
+        - name: master-bosh-root-cert
       platform: linux
       run:
         path: src/ci/update-test-user-credentials.sh

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -270,7 +270,7 @@ resources:
   check_every: 10s
   source:
     uri: https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy
-    branch: main
+    branch: update-test-users
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: dev-opensearch-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -332,13 +332,13 @@ resources:
     region_name: ((aws-region))
     versioned_file: ((master-bosh-cert-file))
 
-- name: weekly
-  type: time
-  source:
-    start: 12:00 AM
-    stop: 1:00 AM
-    location: America/New_York
-    days: [Wednesday]
+# - name: weekly
+#   type: time
+#   source:
+#     start: 12:00 AM
+#     stop: 1:00 AM
+#     location: America/New_York
+#     days: [Wednesday]
 
 
 ############################

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,14 +43,6 @@ jobs:
       text: |
         :x: Tests FAILED on opensearch-dashboards-cf-auth-proxy
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  on_success:
-    put: slack
-    params: &slack-success-params
-      <<: *slack-failure-params
-      channel: ((slack-channel-success))
-      text: |
-        :white_check_mark: Tests PASSED onopensearch-dashboards-cf-auth-proxy
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 - name: deploy-test-apps
   plan:
@@ -127,13 +119,6 @@ jobs:
       <<: *slack-failure-params
       text: |
         :x: FAILED to deploy apps
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  on_success:
-    put: slack
-    params:
-      <<: *slack-success-params
-      text: |
-        :white_check_mark: Successfully deployed apps
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 - name: e2e
@@ -238,13 +223,6 @@ jobs:
       <<: *slack-failure-params
       text: |
         :x: e2e tests FAILED
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-  on_success:
-    put: slack
-    params:
-      <<: *slack-success-params
-      text: |
-        :white_check_mark: e2e tests SUCCEEDED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,8 +7,8 @@ jobs:
     params: {depth: 1}
   - get: master-bosh-root-cert
   - get: general-task
-  # - get: weekly
-  #   trigger: true
+  - get: weekly
+    trigger: true
   - task: update-test-user-credentials
     image: general-task
     config:
@@ -272,7 +272,7 @@ resources:
   check_every: 10s
   source:
     uri: https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy
-    branch: update-test-users
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: dev-opensearch-image
@@ -333,13 +333,13 @@ resources:
     region_name: ((aws-region))
     versioned_file: ((master-bosh-cert-file))
 
-# - name: weekly
-#   type: time
-#   source:
-#     start: 12:00 AM
-#     stop: 1:00 AM
-#     location: America/New_York
-#     days: [Wednesday]
+- name: weekly
+  type: time
+  source:
+    start: 12:00 AM
+    stop: 1:00 AM
+    location: America/New_York
+    days: [Wednesday]
 
 
 ############################

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,5 +1,42 @@
 jobs:
 
+- name: update-test-users-dev
+  serial: true
+  plan:
+  - get: src
+    params: {depth: 1}
+  - get: weekly
+    trigger: true
+  - task: update-test-user-credentials
+    image: general-task
+    config:
+      inputs:
+        - name: src
+        - name: cg-scripts
+      platform: linux
+      run:
+        path: src/ci/update-test-user-credentials.sh
+      params:
+        BOSH_DIRECTOR_NAME: development
+        UAA_API_URL: ((uaa-url-development))
+        UAA_CLIENT_ID: ((uaa-client-id-development))
+        UAA_CLIENT_SECRET: ((uaa-client-secret-development))
+        TEST_USERS_CREDENTIAL_USERNAME_MAP: ((dev-test-users-credential-username-map))
+        CREDHUB_CA_CERT: master-bosh-root-cert/((master-bosh-cert-file))
+        CREDHUB_CLIENT: ((opensearch-proxy-ci-credhub-client-id))
+        CREDHUB_SECRET: ((opensearch-proxy-ci-credhub-client-secret))
+        CREDHUB_SERVER: ((credhub-api-server))
+  on_failure:
+    put: slack
+    params: &slack-failure-params
+      text: |
+        :x: Failed to update test users
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel-failure))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+
 - name: reconfigure
   serial: true
   plan:
@@ -12,13 +49,11 @@ jobs:
       - src/ci/config.yml
   on_failure:
     put: slack
-    params: &slack-failure-params
+    params:
+      <<: *slack-failure-params
       text: |
         :x: Failed to reconfigure pipeline
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel-failure))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
 
 - name: test
   plan:
@@ -290,6 +325,22 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook-url))
+
+- name: master-bosh-root-cert
+  type: s3-iam
+  source:
+    bucket: ((production-bucket-name))
+    region_name: ((aws-region))
+    versioned_file: ((master-bosh-cert-file))
+
+- name: weekly
+  type: time
+  source:
+    interval: 1w
+    start: 12:00 AM
+    stop: 1:00 AM
+    location: America/New_York
+
 
 ############################
 #  RESOURCE TYPES

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -17,7 +17,7 @@ jobs:
         - name: master-bosh-root-cert
       platform: linux
       run:
-        path: src/ci/update-test-user-credentials.sh
+        path: src/ci/update-test-user-passwords.sh
       params:
         BOSH_DIRECTOR_NAME: development
         UAA_API_URL: ((uaa-url-development))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -45,8 +45,6 @@ jobs:
     trigger: true
   - set_pipeline: self
     file: src/ci/pipeline.yml
-    var_files:
-      - src/ci/config.yml
   on_failure:
     put: slack
     params:
@@ -271,8 +269,8 @@ resources:
   icon: github-circle
   check_every: 10s
   source:
-    uri: ((proxy-src-code-uri))
-    branch: ((proxy-src-code-branch))
+    uri: https://github.com/cloud-gov/opensearch-dashboards-cf-auth-proxy
+    branch: main
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: dev-opensearch-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -332,15 +332,6 @@ resources:
     region_name: ((aws-region))
     versioned_file: ((master-bosh-cert-file))
 
-- name: general-task
-  type: registry-image
-  source:
-    aws_access_key_id: ((ecr_aws_key))
-    aws_secret_access_key: ((ecr_aws_secret))
-    repository: general-task
-    aws_region: us-gov-west-1
-    tag: latest
-
 # - name: weekly
 #   type: time
 #   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       text: |
         :x: Failed to update test users
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel-failure))
+      channel: ((slack-channel-customer-success))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -6,6 +6,7 @@ jobs:
   - get: src
     params: {depth: 1}
   - get: master-bosh-root-cert
+  - get: general-task
   # - get: weekly
   #   trigger: true
   - task: update-test-user-credentials

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -335,10 +335,10 @@ resources:
 - name: weekly
   type: time
   source:
-    interval: 1w
     start: 12:00 AM
     stop: 1:00 AM
     location: America/New_York
+    days: [Wednesday]
 
 
 ############################

--- a/ci/update-test-user-passwords.sh
+++ b/ci/update-test-user-passwords.sh
@@ -15,7 +15,7 @@ for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
   credhub regenerate -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name"
 
   # Get the UAA username for the corresponding Credhub credential
-  USERNAME=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq --arg credential_name "$credential_name" '.[$credential_name]')
+  USERNAME=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq -r --arg credential_name "$credential_name" '.[$credential_name]')
 
   echo "updating UAA password for $USERNAME"
 

--- a/ci/update-test-user-passwords.sh
+++ b/ci/update-test-user-passwords.sh
@@ -4,14 +4,18 @@
 uaac target "$UAA_API_URL"
 uaac token client get "$UAA_CLIENT_ID" -s "$UAA_CLIENT_SECRET"
 
-TEST_USER_CREDENTIAL_NAMES=$(echo "$CREDENTIAL_USERNAME_MAP" | jq '. | keys | join(" ")')
+TEST_USER_CREDENTIAL_NAMES=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq '. | keys | join(" ")')
 
 for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
+  echo "updating password credential for $credential_name"
+
   # Generate a new password for the credential
   credhub regenerate -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name"
 
   # Get the UAA username for the corresponding Credhub credential
   USERNAME=$(echo "$CREDENTIAL_USERNAME_MAP" | jq --arg credential_name "$credential_name" '.[$credential_name]')
+
+  echo "updating UAA password for $USERNAME"
 
   # Get the new password from Credhub
   PASSWORD=$(credhub get -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name" --output-json | jq -r '.value')

--- a/ci/update-test-user-passwords.sh
+++ b/ci/update-test-user-passwords.sh
@@ -9,7 +9,7 @@ TEST_USER_CREDENTIAL_NAMES=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq '. 
 for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
   credential_name=$(echo "$credential_name" | tr -d '"')
 
-  echo "updating password credential for $credential_name"
+  printf "updating password credential for %s\n\n" "$credential_name"
 
   # Generate a new password for the credential
   credhub regenerate -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name"
@@ -17,7 +17,7 @@ for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
   # Get the UAA username for the corresponding Credhub credential
   USERNAME=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq -r --arg credential_name "$credential_name" '.[$credential_name]')
 
-  echo "updating UAA password for $USERNAME"
+  printf "updating UAA password for %s\n\n" "$USERNAME"
 
   # Get the new password from Credhub
   PASSWORD=$(credhub get -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name" --output-json | jq -r '.value')

--- a/ci/update-test-user-passwords.sh
+++ b/ci/update-test-user-passwords.sh
@@ -8,14 +8,14 @@ TEST_USER_CREDENTIAL_NAMES=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq '. 
 
 for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
   credential_name=$(echo "$credential_name" | tr -d '"')
-  
+
   echo "updating password credential for $credential_name"
 
   # Generate a new password for the credential
   credhub regenerate -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name"
 
   # Get the UAA username for the corresponding Credhub credential
-  USERNAME=$(echo "$CREDENTIAL_USERNAME_MAP" | jq --arg credential_name "$credential_name" '.[$credential_name]')
+  USERNAME=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq --arg credential_name "$credential_name" '.[$credential_name]')
 
   echo "updating UAA password for $USERNAME"
 

--- a/ci/update-test-user-passwords.sh
+++ b/ci/update-test-user-passwords.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Login to UAA
+uaac target "$UAA_API_URL"
+uaac token client get "$UAA_CLIENT_ID" -s "$UAA_CLIENT_SECRET"
+
+TEST_USER_CREDENTIAL_NAMES=$(echo "$CREDENTIAL_USERNAME_MAP" | jq '. | keys | join(" ")')
+
+for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
+  # Generate a new password for the credential
+  credhub regenerate -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name"
+
+  # Get the UAA username for the corresponding Credhub credential
+  USERNAME=$(echo "$CREDENTIAL_USERNAME_MAP" | jq --arg credential_name "$credential_name" '.[$credential_name]')
+
+  # Get the new password from Credhub
+  PASSWORD=$(credhub get -n "/concourse/main/opensearch-dashboards-cf-auth-proxy/$credential_name" --output-json | jq -r '.value')
+
+  # Update the user password in UAA with the new value from Credhub
+  uaac password set "$USERNAME" --password "$PASSWORD"
+
+  # Activate the user, just to be safe
+  uaac user activate "$USERNAME"
+done
+
+
+

--- a/ci/update-test-user-passwords.sh
+++ b/ci/update-test-user-passwords.sh
@@ -7,6 +7,8 @@ uaac token client get "$UAA_CLIENT_ID" -s "$UAA_CLIENT_SECRET"
 TEST_USER_CREDENTIAL_NAMES=$(echo "$TEST_USERS_CREDENTIAL_USERNAME_MAP" | jq '. | keys | join(" ")')
 
 for credential_name in $TEST_USER_CREDENTIAL_NAMES; do
+  credential_name=$(echo "$credential_name" | tr -d '"')
+  
   echo "updating password credential for $credential_name"
 
   # Generate a new password for the credential


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add pipeline job to update passwords for test users and reactivate them every week, so that e2e tests won't fail after 90 days due to users with expired passwords

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No sensitive data is exposed and communication with UAA happens securely within CI
