### PR TITLE
make SSL required for requests to Redis

### DIFF
--- a/cf_auth_proxy/config.py
+++ b/cf_auth_proxy/config.py
@@ -91,6 +91,7 @@ class AppConfig(Config):
             host=self.env_parser.str("REDIS_HOST"),
             port=6379,
             password=self.env_parser.str("REDIS_PASSWORD", None),
+            ssl=True,
         )
         self.SESSION_COOKIE_SECURE = True
         self.PERMANENT_SESSION_LIFETIME = self.env_parser.int("SESSION_LIFETIME")
@@ -122,3 +123,7 @@ class LocalConfig(AppConfig):
         self.TESTING = True
         self.DEBUG = True
         self.SESSION_COOKIE_SECURE = False
+        self.SESSION_REDIS = Redis(
+            host=self.env_parser.str("REDIS_HOST"),
+            port=6379,
+        )


### PR DESCRIPTION
## Changes proposed in this pull request:

- make SSL required for requests to Redis

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Requiring SSL for requests to Redis reduces the changes of eavesdropping or man-in-the-middle attacks
