### PR TITLE
Update OpenSearch docker image versions

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -191,7 +191,7 @@ jobs:
       - get: src
         params: {depth: 1}
         trigger: true
-        passed: [deploy-test-apps]
+        passed: [update-test-app-networking]
       - get: general-task
       - get: playwright-python
     - task: provision-cf-access

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -120,6 +120,8 @@ jobs:
 - name: deploy-opensearch-test-apps
   plan:
     - in_parallel:
+      - get: src
+        passed: [test]
       - get: dev-opensearch-image
         trigger: true
       - get: dev-opensearch-dashboards-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -79,13 +79,47 @@ jobs:
         :x: Tests FAILED on opensearch-dashboards-cf-auth-proxy
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: deploy-test-apps
+- name: deploy-test-proxy-app
   plan:
     - in_parallel:
       - get: src
         params: {depth: 1}
         passed: [test]
-      - get: general-task
+        trigger: true
+
+    - put: cf-dev
+      params:
+        path: src
+        manifest: src/cf/proxy-manifest.yml
+        vars:
+          cf_url: ((dev-cf-api-url))
+          uaa_auth_url: ((dev-uaa-auth-url))
+          uaa_base_url: ((dev-uaa-base-url))
+          uaa_client_id: ((dev-uaa-test-client-id))
+          uaa_client_secret: ((dev-uaa-test-client-secret))
+          # note: when setting this in credhub, be sure to include extra single quotes, e.g.
+          # credhub set -t value -n /path/to/dev-uaa-jwks -v "'"'{"keys":[]}'"'"
+          uaa_jwks: ((dev-uaa-jwks))
+          secret_key: ((dev-secret-key))
+          session_lifetime: "3600"
+          public_route: ((dev-test-public-url))
+          dashboard_url: ((dev-test-dashboard-url))
+          auth_proxy_app_name: ((dev-test-auth-proxy-app-name))
+          auth_proxy_num_instances: ((dev-test-auth-proxy-num-instances))
+          redis_host: ((dev-redis-host))
+          redis_password: ((dev-redis-password))
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-failure-params
+      text: |
+        :x: FAILED to deploy test proxy app
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+
+
+- name: deploy-opensearch-test-apps
+  plan:
+    - in_parallel:
       - get: dev-opensearch-image
         trigger: true
       - get: dev-opensearch-dashboards-image
@@ -110,29 +144,22 @@ jobs:
           opensearch_password: ((opensearch-admin-password))
           repo: ((ecr_aws_repo))
           docker_username: ((ecr_aws_key))
+  on_failure:
+    put: slack
+    params:
+      <<: *slack-failure-params
+      text: |
+        :x: FAILED to deploy OpenSearch test apps
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-    - put: cf-dev
-      params:
-        path: src
-        manifest: src/cf/proxy-manifest.yml
-        vars:
-          cf_url: ((dev-cf-api-url))
-          uaa_auth_url: ((dev-uaa-auth-url))
-          uaa_base_url: ((dev-uaa-base-url))
-          uaa_client_id: ((dev-uaa-test-client-id))
-          uaa_client_secret: ((dev-uaa-test-client-secret))
-          # note: when setting this in credhub, be sure to include extra single quotes, e.g.
-          # credhub set -t value -n /path/to/dev-uaa-jwks -v "'"'{"keys":[]}'"'"
-          uaa_jwks: ((dev-uaa-jwks))
-          secret_key: ((dev-secret-key))
-          session_lifetime: "3600"
-          public_route: ((dev-test-public-url))
-          dashboard_url: ((dev-test-dashboard-url))
-          auth_proxy_app_name: ((dev-test-auth-proxy-app-name))
-          auth_proxy_num_instances: ((dev-test-auth-proxy-num-instances))
-          redis_host: ((dev-redis-host))
-          redis_password: ((dev-redis-password))
-
+- name: update-test-app-networking
+  plan:
+    - in_parallel:
+      - get: general-task
+      - get: src
+        params: {depth: 1}
+        passed: [deploy-test-proxy-app, deploy-opensearch-test-apps]
+        trigger: true
     - task: update-networking
       image: general-task
       config:
@@ -155,7 +182,7 @@ jobs:
     params:
       <<: *slack-failure-params
       text: |
-        :x: FAILED to deploy apps
+        :x: FAILED to update test app networking
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 - name: e2e

--- a/docker/opensearch/dockerfile
+++ b/docker/opensearch/dockerfile
@@ -1,6 +1,6 @@
 ARG base_image=ubuntu:22.04
 
-FROM opensearchproject/opensearch:2.12.0 AS opensearch
+FROM opensearchproject/opensearch:2.17.0 AS opensearch
 
 # ok, this is a little weird.
 # we're building this image to run on Cloud Foundry, where we can

--- a/docker/opensearch_dashboards/dockerfile
+++ b/docker/opensearch_dashboards/dockerfile
@@ -1,6 +1,6 @@
 ARG base_image=ubuntu:22.04
 
-FROM opensearchproject/opensearch-dashboards:2.12.0 AS opensearch-dashboards
+FROM opensearchproject/opensearch-dashboards:2.17.0 AS opensearch-dashboards
 
 
 FROM ${base_image}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update OpenSearch docker image versions to 2.17.0 to match the BOSH release blobs
- Refactor pipeline to ensure proxy app redeploys on any changes

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just updating Docker image versions for testing
