### PR TITLE
Update logic for fetching CF entities used in proxy headers

### DIFF
--- a/cf_auth_proxy/cf.py
+++ b/cf_auth_proxy/cf.py
@@ -28,7 +28,7 @@ def get_spaces_for_user(user_id, token):
         first_response = s.get(url, params=params)
         resources = iterate_cf_resource(s, first_response)
     spaces = [r["relationships"]["space"]["data"]["guid"] for r in resources]
-    return spaces
+    return list(set(spaces))
 
 
 def get_permitted_orgs_for_user(user_id, token):
@@ -42,7 +42,7 @@ def get_permitted_orgs_for_user(user_id, token):
         first_response = s.get(url, params=params)
         resources = iterate_cf_resource(s, first_response)
     orgs = [r["relationships"]["organization"]["data"]["guid"] for r in resources]
-    return orgs
+    return list(set(orgs))
 
 
 def get_all_orgs_for_user(user_id, token):
@@ -56,4 +56,4 @@ def get_all_orgs_for_user(user_id, token):
         first_response = s.get(url, params=params)
         resources = iterate_cf_resource(s, first_response)
     orgs = [r["relationships"]["organization"]["data"]["guid"] for r in resources]
-    return orgs
+    return list(set(orgs))

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -127,7 +127,7 @@ def test_gets_unique_spaces():
         response_1 = """
   {
    "pagination": {
-      "total_results": 2,
+      "total_results": 3,
       "total_pages": 2,
       "first": {
          "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
@@ -178,7 +178,7 @@ def test_gets_unique_spaces():
         response_2 = """
   {
    "pagination": {
-      "total_results": 2,
+      "total_results": 3,
       "total_pages": 2,
       "first": {
          "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -275,9 +275,9 @@ def test_gets_unique_spaces():
 def test_gets_cf_user_permitted_orgs():
     with requests_mock.Mocker() as m:
         response_1 = """
-  {
+{
    "pagination": {
-      "total_results": 2,
+      "total_results": 3,
       "total_pages": 2,
       "first": {
          "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_manager%2Corganization_auditor&user_guids=a-user-guid"
@@ -322,9 +322,9 @@ def test_gets_cf_user_permitted_orgs():
                "href": "http://mock.cf/v3/organization/org-guid-1"
             }
          }
-        }
-      ]
-    } """
+      }
+   ]
+} """
         response_2 = """
   {
    "pagination": {
@@ -373,9 +373,41 @@ def test_gets_cf_user_permitted_orgs():
                "href": "http://mock.cf/v3/organizations/org-guid-2"
             }
          }
-        }
-      ]
-    }
+      },
+      {
+         "guid": "role-guid-3",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "organization_auditor",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "organization": {
+               "data": {
+                  "guid": "org-guid-2"
+               }
+            },
+            "space": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "http://mock.cf/v3/roles/role-guid-3"
+            },
+            "user": {
+               "href": "http://mock.cf/v3/users/a-user-guid"
+            },
+            "organization": {
+               "href": "http://mock.cf/v3/organizations/org-guid-2"
+            }
+         }
+      }
+   ]
+}
     """
         m.get(
             "http://mock.cf/v3/roles?user_guids=a-user-id&types=organization_manager,organization_auditor",
@@ -395,7 +427,7 @@ def test_gets_cf_user_all_orgs():
         response_1 = """
   {
    "pagination": {
-      "total_results": 2,
+      "total_results": 3,
       "total_pages": 2,
       "first": {
          "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_user&user_guids=a-user-guid"
@@ -444,9 +476,9 @@ def test_gets_cf_user_all_orgs():
       ]
     } """
         response_2 = """
-  {
+{
    "pagination": {
-      "total_results": 2,
+      "total_results": 3,
       "total_pages": 2,
       "first": {
          "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=organization_user&user_guids=a-user-guid"
@@ -491,9 +523,41 @@ def test_gets_cf_user_all_orgs():
                "href": "http://mock.cf/v3/organizations/org-guid-2"
             }
          }
-        }
-      ]
-    }
+      },
+      {
+         "guid": "role-guid-3",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "org_user",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "organization": {
+               "data": {
+                  "guid": "org-user-2"
+               }
+            },
+            "space": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "http://mock.cf/v3/roles/role-guid-3"
+            },
+            "user": {
+               "href": "http://mock.cf/v3/users/a-user-guid"
+            },
+            "organization": {
+               "href": "http://mock.cf/v3/organizations/org-guid-2"
+            }
+         }
+      }
+   ]
+}
     """
         m.get(
             "http://mock.cf/v3/roles?user_guids=a-user-id&types=organization_user",

--- a/tests/unit/test_cf.py
+++ b/tests/unit/test_cf.py
@@ -122,6 +122,156 @@ def test_gets_spaces():
         )
 
 
+def test_gets_unique_spaces():
+    with requests_mock.Mocker() as m:
+        response_1 = """
+  {
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 2,
+      "first": {
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+      },
+      "next": {
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+      },
+      "previous": null
+   },
+   "resources": [
+      {
+         "guid": "role-guid-1",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "space_developer",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-guid-1"
+               }
+            },
+            "organization": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "http://mock.cf/v3/roles/role-guid-1"
+            },
+            "user": {
+               "href": "http://mock.cf/v3/users/a-user-guid"
+            },
+            "space": {
+               "href": "http://mock.cf/v3/spaces/space-guid-1"
+            }
+         }
+        }
+      ]
+    } """
+        response_2 = """
+  {
+   "pagination": {
+      "total_results": 2,
+      "total_pages": 2,
+      "first": {
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+      },
+      "last": {
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+      },
+      "next": null,
+      "previous": {
+         "href": "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=1&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid"
+      }
+   },
+   "resources": [
+      {
+         "guid": "role-guid-2",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "space_developer",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-guid-2"
+               }
+            },
+            "organization": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "http://mock.cf/v3/roles/role-guid-2"
+            },
+            "user": {
+               "href": "http://mock.cf/v3/users/a-user-guid"
+            },
+            "space": {
+               "href": "http://mock.cf/v3/spaces/space-guid-2"
+            }
+         }
+        },
+      {
+         "guid": "role-guid-3",
+         "created_at": "2019-12-12T18:59:12Z",
+         "updated_at": "2019-12-12T18:59:13Z",
+         "type": "space_developer",
+         "relationships": {
+            "user": {
+               "data": {
+                  "guid": "a-user-guid"
+               }
+            },
+            "space": {
+               "data": {
+                  "guid": "space-guid-2"
+               }
+            },
+            "organization": {
+               "data": null
+            }
+         },
+         "links": {
+            "self": {
+               "href": "http://mock.cf/v3/roles/role-guid-3"
+            },
+            "user": {
+               "href": "http://mock.cf/v3/users/a-user-guid"
+            },
+            "space": {
+               "href": "http://mock.cf/v3/spaces/space-guid-2"
+            }
+         }
+        }
+      ]
+    }
+    """
+        m.get(
+            "http://mock.cf/v3/roles?user_guids=a-user-id&types=space_developer,space_manager,space_auditor",
+            text=response_1,
+        )
+        m.get(
+            "http://mock.cf/v3/roles?order_by=%2Bcreated_at&page=2&per_page=1&types=space_developer%2Cspace_manager%2Cspace_auditor&user_guids=a-user-guid",
+            text=response_2,
+        )
+        assert sorted(cf.get_spaces_for_user("a-user-id", "a_token")) == sorted(
+            ["space-guid-1", "space-guid-2"]
+        )
+
+
 def test_gets_cf_user_permitted_orgs():
     with requests_mock.Mocker() as m:
         response_1 = """


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/2032

- Update logic for fetching CF entities (org, spaces) used as proxy headers to ensure that only **unique values** are returned. The CF API endpoints may return the same org or space GUID in the results, which is redundant, but also causes the headers using these values to be larger than necessary
- Add unit tests for updated CF entity fetching logic

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Nothing about the mechanics of how the proxy passes information to OpenSearch via headers has changed, we have just fixed a bug that was causing duplicate information to be sent.
